### PR TITLE
Generalize undo db

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 #### Changed
 
+- `undoable` takes a second argument, the derefable object to apply undo/redo to. Default 0 and 1 argument versions use the `app-db`.
+- `undo-list` and `redo-list` have a slightly different schema. They are now lists of pairs where each item in the list represents a change (as before) and the pair corresponds to the derefable and the change's state (what used to occupy the item's location in the list).
+- `undoable` has a `:before` case where a non-`app-db` is pushed to the stack of changes. This is because calling for example `(reset! external-db {:test 3})` occurs before the :after case. So, to capture the initial state, `store-now!` must be called before the body of the event transpires. Perhaps a `reg-fx` may be in order, but I didn't know how to write one that would do the job more elegantly.
+- Tests in the style as before were added. They use an event which modifies an artificial db object (a local `ratom`)
 - Make everything public. No private defs.
 - Migrate to [shadow-cljs](https://shadow-cljs.github.io/docs/UsersGuide.html) and
   [lein-shadow](https://gitlab.com/nikperic/lein-shadow)

--- a/test/day8/re_frame/undo/undo_test.cljs
+++ b/test/day8/re_frame/undo/undo_test.cljs
@@ -20,7 +20,7 @@
   (is (not (undo/redos?)))
 
   (doseq [i (range 10)]
-    (undo/store-now! (inc i))
+    (undo/store-now! (inc i) db/app-db)
     (reset! db/app-db {:test (inc i)}))
 
   ;; Check the undo state is correct
@@ -144,3 +144,41 @@
   (is (undo/undos?))
   (is (= [{:test 5} {:test 6} {:test 7} {:test 8} {:test 9}]
         (map second @undo/undo-list))))
+(deftest test-general-undo-db
+  (let [external-db (reagent.core/atom {:test nil})]
+    (re-frame/reg-event-fx :change-db-fx
+      (undo/undoable nil external-db)
+      (fn [_ _]
+        (let [db         @external-db
+              update-num (inc (:test db))]
+          (reset! external-db (assoc db :test update-num))
+          {:undo (str "change-db " update-num)})))
+    (doseq [i (range 10)] (re-frame/dispatch-sync [:change-db-fx]))
+    ;; Check the undo state is correct
+    (is (undo/undos?))
+    (is (not (undo/redos?)))
+    (is (= [nil nil nil nil nil nil] (undo/undo-explanations)))
+    (is (= [{:test 5} {:test 6} {:test 7} {:test 8} {:test 9}]
+           (map second @undo/undo-list)))
+    ;; Undo the actions
+    (re-frame/dispatch-sync [:undo])
+    (is (= @external-db {:test 9}))
+    (is (undo/redos?))
+    (re-frame/dispatch-sync [:undo])
+    (is (= @external-db {:test 8}))
+    (re-frame/dispatch-sync [:undo])
+    (is (= @external-db {:test 7}))
+    (re-frame/dispatch-sync [:undo])
+    (is (= @external-db {:test 6}))
+    (re-frame/dispatch-sync [:undo])
+    (is (= @external-db {:test 5}))
+    (is (not (undo/undos?)))
+    (is (undo/redos?))
+    ;; Redo them again
+    (re-frame/dispatch-sync [:redo 5])
+    (is (= @external-db {:test 10}))
+    (is (not (undo/redos?)))
+    (is (undo/undos?))
+    (is (= [{:test 5} {:test 6} {:test 7} {:test 8} {:test 9}]
+           (map second @undo/undo-list)))))
+

--- a/test/day8/re_frame/undo/undo_test.cljs
+++ b/test/day8/re_frame/undo/undo_test.cljs
@@ -27,7 +27,7 @@
   (is (undo/undos?))
   (is (not (undo/redos?)))
   (is (= [5 6 7 8 9 10] (undo/undo-explanations)))
-  (is (= [{:test 5} {:test 6} {:test 7} {:test 8} {:test 9}] @undo/undo-list))
+  (is (= [{:test 5} {:test 6} {:test 7} {:test 8} {:test 9}] (map second @undo/undo-list)))
 
   ;; Undo the actions
   (re-frame/dispatch-sync [:undo])
@@ -50,7 +50,7 @@
   (is (not (undo/redos?)))
   (is (undo/undos?))
   (is (= [{:test 5} {:test 6} {:test 7} {:test 8} {:test 9}]
-         @undo/undo-list))
+        (map second @undo/undo-list)))
 
   ;; Clear history
   (undo/clear-history!)
@@ -73,9 +73,9 @@
   (is (undo/undos?))
   (is (not (undo/redos?)))
   (is (= ["change-db" "change-db" "change-db" "change-db" "change-db" "change-db"]
-         (undo/undo-explanations)))
+        (undo/undo-explanations)))
   (is (= [{:test 5} {:test 6} {:test 7} {:test 8} {:test 9}]
-         @undo/undo-list))
+        (map second @undo/undo-list)))
 
   ;; Undo the actions
   (re-frame/dispatch-sync [:undo])
@@ -98,7 +98,7 @@
   (is (not (undo/redos?)))
   (is (undo/undos?))
   (is (= [{:test 5} {:test 6} {:test 7} {:test 8} {:test 9}]
-         @undo/undo-list)))
+        (map second @undo/undo-list))))
 
 (deftest test-undos-interceptor-description
 
@@ -118,9 +118,9 @@
   (is (not (undo/redos?)))
   (is (= ["change-db 5" "change-db 6" "change-db 7" "change-db 8" "change-db 9"
           "change-db 10"]
-         (undo/undo-explanations)))
+        (undo/undo-explanations)))
   (is (= [{:test 5} {:test 6} {:test 7} {:test 8} {:test 9}]
-         @undo/undo-list))
+        (map second @undo/undo-list)))
 
   ;; Undo the actions
   (re-frame/dispatch-sync [:undo])
@@ -143,4 +143,4 @@
   (is (not (undo/redos?)))
   (is (undo/undos?))
   (is (= [{:test 5} {:test 6} {:test 7} {:test 8} {:test 9}]
-         @undo/undo-list)))
+        (map second @undo/undo-list))))


### PR DESCRIPTION
## Motivation
I found myself wanting to undo events that modified atoms other than the app-db. 

## Summary
The changes here are for an additional argument to `undoable` which specifies the derefable object for which an undo event corresponds. This object, something that resembles `re-frame/app-db`, is stored alongside the undo data and is used for the pop/push actions corresponding to the undo/redo functions. Of course, by default (if left unspecified), the standard `app-db` is used.

## Changes
- `undoable` takes a second argument, the derefable object to apply undo/redo to. Default 0 and 1 argument versions use the `app-db`.
- `undo-list` and `redo-list` have a slightly different schema. They are now lists of pairs where each item in the list represents a change (as before) and the pair corresponds to the derefable and the change's state (what used to occupy the item's location in the list).
- `undoable` has a `:before` case where a non-`app-db` is pushed to the stack of changes. This is because calling for example `(reset! external-db {:test 3})` occurs before the :after case. So, to capture the initial state, `store-now!` must be called before the body of the event transpires. Perhaps a `reg-fx` may be in order, but I didn't know how to write one that would do the job more elegantly.
- Tests in the style as before were added. They use an event which modifies an artificial db object (a local `ratom`)

## Caveats
- The derefable object replacing app-db must be known by the user/developer when writing the event with this interceptor. It has to be specified at the time the event is registered. Maybe an `fx` or `cofx` handler could allow for dynamically determining the derefable object to use.
- Only one derefable can receive the undo facilities per event. This could be overcome via dispatch on behalf of the user perhaps.
- The schema for the `undo-list` and `redo-list` has changed. Anyone inspecting these manually (rare I'd think) will experience breaking changes to their app.