### PR TITLE
Allow user to inject interceptors to undo and redo event handlers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ pom.xml.asc
 .idea/
 /.shadow-cljs/
 /shadow-cljs.edn
+.clj-kondo/
+.lsp/
+resources/

--- a/README.md
+++ b/README.md
@@ -303,6 +303,19 @@ function once, during startup:
 (day8.re-frame.undo/undo-config! {:max-undos 100})
 ```
 
+You might want to intercept the `:undo` and `:redo` events to run some custom code. You can inject re-frame interceptors that will be run when `:undo` and `:redo` events are dispatched. This too, is meant to be called once during app startup:
+
+```clj
+(day8.re-frame.undo/register-events-subs!
+  [(rf/->interceptor
+  :before (fn [ctx]
+            (println "access the context object here")
+            ctx))
+  (rf/->interceptor
+  :after (fn [ctx]
+           (println "access the context object here")
+           ctx))])
+```
 
 ### Fancy Explanations With `undoable`
 

--- a/src/day8/re_frame/undo.cljs
+++ b/src/day8/re_frame/undo.cljs
@@ -227,15 +227,19 @@
 
 
 (defn register-events-subs!
-  []
-  (re-frame/reg-event-fx
+  ([] (register-events-subs! []))
+  ([interceptors]
+   (re-frame/reg-event-fx
     :undo                     ;; usage:  (dispatch [:undo n])  n is optional, defaults to 1
+    interceptors
     undo-handler)
-  (re-frame/reg-event-fx
+   (re-frame/reg-event-fx
     :redo                     ;; usage:  (dispatch [:redo n])
+    interceptors
     redo-handler)
-  (re-frame/reg-event-db
+   (re-frame/reg-event-db
     :purge-redos              ;; usage:  (dispatch [:purge-redos])
-    purge-redo-handler))
+    interceptors
+    purge-redo-handler)))
 
 (register-events-subs!)


### PR DESCRIPTION
This demo PR is sort of a proposal to add interceptors to the undo and redo event handlers. This lets the user of the lib to use co-effects and create effects whenever the `:undo` and `:redo` events are dispatched.